### PR TITLE
Fix comment typo

### DIFF
--- a/dspy/teleprompt/bettertogether.py
+++ b/dspy/teleprompt/bettertogether.py
@@ -139,7 +139,7 @@ class BetterTogether(Teleprompter):
         # predictor.lm attributes. In particular,
         # BootstrapFewShotWithRandomSearch seems to be resetting these. We are
         # manually re-setting the LMs here to circumvent this issue, but we
-        # should consider adressing it in BFRS.
+        # should consider addressing it in BFRS.
         logger.info("Compiling the prompt optimizer...")
         pred_lms = [pred.lm for pred in student.predictors()]
         student = self.prompt_optimizer.compile(student, trainset=prompt_trainset, valset=prompt_valset)


### PR DESCRIPTION
## Summary
- fix spelling of "addressing" in BetterTogether comment

## Testing
- `pytest tests/predict` *(fails: pytest not installed)*
- `pip install -e .[dev]` *(fails: could not fetch dependencies)*