### PR TITLE
Fix dataset test tmpfile

### DIFF
--- a/tests/datasets/test_dataset.py
+++ b/tests/datasets/test_dataset.py
@@ -1,3 +1,4 @@
+import tempfile
 import unittest
 import uuid
 
@@ -10,9 +11,6 @@ dummy_data = """content,question,answer
 "This is content 1","What is this?","This is answer 1"
 "This is content 2","What is that?","This is answer 2"
 """
-
-with open("dummy.csv", "w") as file:
-    file.write(dummy_data)
 
 
 class CSVDataset(Dataset):
@@ -32,17 +30,18 @@ class CSVDataset(Dataset):
 
 class TestCSVDataset(unittest.TestCase):
     def test_input_keys(self):
-        dataset = CSVDataset("dummy.csv", input_keys=["content", "question"])
-        self.assertIsNotNone(dataset.train)
+        with tempfile.NamedTemporaryFile(mode="w+", suffix=".csv") as tmp_file:
+            tmp_file.write(dummy_data)
+            tmp_file.flush()
+            dataset = CSVDataset(tmp_file.name, input_keys=["content", "question"])
+            self.assertIsNotNone(dataset.train)
 
-        for example in dataset.train:
-            print(example)
-            inputs = example.inputs()
-            print(f"Example inputs: {inputs}")
-            self.assertIsNotNone(inputs)
-            self.assertIn("content", inputs)
-            self.assertIn("question", inputs)
-            self.assertEqual(set(example._input_keys), {"content", "question"})
+            for example in dataset.train:
+                inputs = example.inputs()
+                self.assertIsNotNone(inputs)
+                self.assertIn("content", inputs)
+                self.assertIn("question", inputs)
+                self.assertEqual(set(example._input_keys), {"content", "question"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- use `NamedTemporaryFile` in dataset tests
- drop stray prints

## Testing
- `pytest tests/datasets/test_dataset.py -q`
- `pre-commit run --files tests/datasets/test_dataset.py` *(fails: unable to fetch ruff-pre-commit)*