### PR TITLE
Fix usage tracker merging bug

### DIFF
--- a/dspy/utils/usage_tracker.py
+++ b/dspy/utils/usage_tracker.py
@@ -43,6 +43,8 @@ class UsageTracker:
                 else:
                     result[k] = result[k] or 0
                     result[k] += v if v else 0
+            else:
+                result[k] = dict(v) if isinstance(v, dict) else v
         return result
 
     def add_usage(self, lm: str, usage_entry: dict):

--- a/tests/utils/test_usage_tracker.py
+++ b/tests/utils/test_usage_tracker.py
@@ -157,3 +157,16 @@ def test_track_usage_context_manager():
     assert "openai/gpt-4o-mini" in total_usage
     assert len(total_usage.keys()) == 1
     assert isinstance(total_usage["openai/gpt-4o-mini"], dict)
+
+
+def test_merge_usage_entries_with_new_keys():
+    """Ensure merging usage entries preserves unseen keys."""
+    tracker = UsageTracker()
+
+    tracker.add_usage("model-x", {"prompt_tokens": 5})
+    tracker.add_usage("model-x", {"completion_tokens": 2})
+
+    total_usage = tracker.get_total_tokens()
+
+    assert total_usage["model-x"]["prompt_tokens"] == 5
+    assert total_usage["model-x"]["completion_tokens"] == 2


### PR DESCRIPTION
## Summary
- preserve unseen keys when merging token usage entries
- add regression test for usage tracker
- revert accidental changes to `uv.lock`

## Testing
- `uv run python -m pytest tests/utils/test_usage_tracker.py::test_merge_usage_entries_with_new_keys -q`